### PR TITLE
Bugfix/Fix memory leak

### DIFF
--- a/Sources/FormManager.swift
+++ b/Sources/FormManager.swift
@@ -48,7 +48,9 @@ public class FormManager: ObservableObject {
     /// Used internally for adding a validator
     public func append(_ validator: ValidatorContainer) {
         var val = validator.validator
-        val.observeChange(onChanged)
+        val.observeChange { [weak self] validation in
+          self?.onChanged(validation: validation)
+        }
         validators.append(validator)
     }
 


### PR DESCRIPTION
This PR fixes a memory leak in `FormManager` caused by strongly capturing `self` in a closure.

